### PR TITLE
[TASK] Adjust TSconfig registration for TYPO3 v13 compatibility

### DIFF
--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -1,0 +1,1 @@
+@import 'EXT:pluploadfe/Configuration/TSconfig/page.tsconfig'

--- a/Configuration/user.tsconfig
+++ b/Configuration/user.tsconfig
@@ -1,0 +1,1 @@
+options.saveDocNew.tx_pluploadtest_config = 1

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,16 +1,19 @@
 <?php
 
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 defined('TYPO3') || die();
 
 call_user_func(static function ($packageKey) {
-    ExtensionManagementUtility::addPageTSConfig(
-        '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:'.$packageKey.'/Configuration/TSconfig/page.tsconfig">'
-    );
-    ExtensionManagementUtility::addUserTSConfig('
-        options.saveDocNew.tx_pluploadtest_config=1
-    ');
+    $versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
+    // Only include user.tsconfig if TYPO3 version is below 13 so that it is not imported twice.
+    if ($versionInformation->getMajorVersion() < 13) {
+        ExtensionManagementUtility::addUserTSConfig(
+            '@import "EXT:pluploadfe/Configuration/user.tsconfig"',
+        );
+    }
 
     // Add plugin
     ExtensionManagementUtility::addPItoST43(


### PR DESCRIPTION
## Description

The registration of PageTSconfig and UserTSconfig was updated to follow TYPO3 v13 best practices:

* Replaced `addPageTSConfig()` with `@import` syntax.
* Added conditional registration of `user.tsconfig` to avoid duplicate inclusion in TYPO3 v13, based on `Typo3Version`.

## References

* Deprecation of `ExtensionManagementUtility::addPageTSConfig()` (see [#101799](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Deprecation-101799-ExtensionManagementUtilityaddPageTSConfig.html))
* [UserTSconfig import syntax compatible with TYPO3 v12 and v13](https://docs.typo3.org/m/typo3/reference-typoscript/13.4/en-us/UsingSettingTSconfig/UserTSconfig.html#user-tsconfig-compatible-with-typo3-v12-and-v13)