### PR TITLE
[BUGFIX] Fix RenderViewHelper request handling for TYPO3 v12

### DIFF
--- a/Classes/ViewHelpers/RenderViewHelper.php
+++ b/Classes/ViewHelpers/RenderViewHelper.php
@@ -10,6 +10,8 @@ namespace FelixNagel\Pluploadfe\ViewHelpers;
  */
 
 use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -44,6 +46,11 @@ class RenderViewHelper extends AbstractViewHelper
 
     protected function getRequest(): ServerRequestInterface
     {
+        // @todo Remove this when TYPO3 12 is no longer relevant!
+        if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() < 13) {
+            return $this->renderingContext->getRequest();
+        }
+
         return $this->renderingContext->getAttribute(ServerRequestInterface::class);
     }
 }


### PR DESCRIPTION
Adjust RenderViewHelper to retrieve the PSR-7 request in a TYPO3 v12–compatible way by using RenderingContext->getRequest(), while keeping the attribute-based access for TYPO3 v13+.

Resolves #28